### PR TITLE
Feature/is-yarn-installed

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,29 @@
 'use strict';
-const path = require('path');
-const fs = require('fs');
+const {isYarnInstalled, isValidOptions, isYarnUsed} = require('./lib/lib');
 
-module.exports = cwd => fs.existsSync(path.resolve(cwd || process.cwd(), 'yarn.lock'));
+function hasYarn(...args) {
+	if (args.length > 1) {
+		throw new Error(`Invalid parameter: ${args[1]}`);
+	}
+
+	if (['string', 'object', 'undefined'].lastIndexOf(typeof args[0]) === -1) {
+		throw new Error(`Invalid parameter type.\nType ${typeof args[0]} is not supported.`);
+	}
+
+	if (typeof args[0] === 'string' || typeof args[0] === 'undefined') {
+		const cwd = args[0];
+		return isYarnUsed(cwd);
+	}
+
+	if (typeof args[0] === 'object') {
+		const options = args[0];
+		isValidOptions(options);
+		if (options.onMachine) {
+			return isYarnInstalled();
+		}
+
+		return hasYarn();
+	}
+}
+
+module.exports = hasYarn;

--- a/lib/lib.js
+++ b/lib/lib.js
@@ -1,0 +1,38 @@
+const path = require('path');
+const fs = require('fs');
+const {exec} = require('shelljs');
+
+/**
+ * Checks whether yarn is installed on the machine or not.
+ * @returns {boolean} true if yarn is installed on the machine otherwise false.
+ */
+function isYarnInstalled() {
+	const yarnVersion = exec('yarn --version', {silent: true}).stdout.trim();
+	return /^(\d+)((\.{1}\d+)*)(\.{0})$/.test(yarnVersion);
+}
+
+/**
+ * Checks whether yarn is used in a project or not.
+ *
+ * @param {string} cwd project's path where you want to check if yarn is used,
+ * if undefined process current working directory will be used.
+ * @returns {Boolean} true if yarn is used.
+ */
+function isYarnUsed(cwd) {
+	return fs.existsSync(path.resolve(cwd || process.cwd(), 'yarn.lock'));
+}
+
+/**
+ * Validates hasYarn options object.
+ * @param {Object} options - hasYarn options object.
+ * @param {boolean} options.onMachine - set it to true to check whether yarn is installed on the machine or not.
+ * @returns {undefined} if valid returns nothing/undefined otherwise will throw errors for invalid options.
+ */
+function isValidOptions(options) {
+	// Currently support only one option: options['onMachine']
+	if (Object.keys(options).length > 1 || typeof options.onMachine !== 'boolean') {
+		throw new Error('Invalid options object');
+	}
+}
+
+module.exports = {isYarnInstalled, isValidOptions, isYarnUsed};

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
 		"node": ">=8"
 	},
 	"scripts": {
-		"test": "xo && ava"
+		"test": "xo && ava",
+		"lint:fix": "xo --fix"
 	},
 	"files": [
 		"index.js"
@@ -33,5 +34,8 @@
 	"devDependencies": {
 		"ava": "^1.2.1",
 		"xo": "^0.24.0"
+	},
+	"dependencies": {
+		"shelljs": "^0.8.3"
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -1,18 +1,18 @@
 # has-yarn [![Build Status](https://travis-ci.org/sindresorhus/has-yarn.svg?branch=master)](https://travis-ci.org/sindresorhus/has-yarn)
 
-> Check if a project is using [Yarn](https://yarnpkg.com)
+> Check if [Yarn](https://yarnpkg.com) is used in a project or installed on the machine.
 
 Useful for tools that needs to know whether to use `yarn` or `npm` to install dependencies.
 
-Checks if a `yarn.lock` file is present in the working directory.
+- When checking whether a project is using yarn, it checks if a `yarn.lock` file is present in the working directory.
 
+- When checking if yarn is installed on the machine it executes a silent shell command to check if yarn has been installed on the machine or not.
 
 ## Install
 
 ```
 $ npm install has-yarn
 ```
-
 
 ## Usage
 
@@ -33,22 +33,42 @@ hasYarn('foo');
 
 hasYarn('bar');
 //=> true
-```
 
+// with options object
+hasYarn({onMachine : true});
+//=> true if yarn is installed on the machine otherwise false.
+
+```
 
 ## API
 
-### hasYarn([cwd])
+### hasYarn([cwd | options])
 
 Returns a `boolean`.
 
 #### cwd
 
-Type: `string`<br>
+Type: `string` <br>
+
 Default: `process.cwd()`
 
 Current working directory.
 
+#### options
+
+Type: `object`<br>
+
+##### options.onMachine
+
+Type: `boolean`<br>
+
+If set to true, will check if yarn is installed on the machine otherwise will fallback to `hasYarn` in the current working directory.
+
+```js
+hasYarn({onMachine : false}); // is the same as
+hasYarn();
+
+```
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -1,8 +1,17 @@
 import test from 'ava';
+import {isYarnInstalled} from './lib/lib';
 import hasYarn from '.';
 
 test('main', t => {
 	t.true(hasYarn('fixtures/bar'));
 	t.false(hasYarn('fixtures/foo'));
 	t.false(hasYarn());
+	const invlaidParamType = 123456789;
+	const invalidParamtypeError = t.throws(() => hasYarn(invlaidParamType));
+	t.is(invalidParamtypeError.message, `Invalid parameter type.\nType ${typeof invlaidParamType} is not supported.`);
+	const invalidParamsError = t.throws(() => hasYarn('param1', 'param2', 'param3'));
+	t.is(invalidParamsError.message, 'Invalid parameter: param2');
+	const invalidOptionsError = t.throws(() => hasYarn({key1: 'val-1', key2: 'val-2', key3: 'val-3'}));
+	t.is(invalidOptionsError.message, 'Invalid options object');
+	t.is(hasYarn({onMachine: true}), isYarnInstalled());
 });


### PR DESCRIPTION
**Extended `hasYarn` function to also be able to check if `yarn` is installed on the machine or not.**

```js
//e.g. 

if(hasYarn({onMachine:true}) && hasyarn('path/to/check_dir')){
// use yarn
}
else{
// use npm
}
```